### PR TITLE
Fixed configuration path

### DIFF
--- a/lib/capistrano/php_fpm/sysv_upstart.rb
+++ b/lib/capistrano/php_fpm/sysv_upstart.rb
@@ -1,2 +1,2 @@
-load File.expand_path('../php-fpm.rake', __FILE__) # Load configuration options
+load File.expand_path('../php_fpm.rake', __FILE__) # Load configuration options
 load File.expand_path('../tasks/sysv_upstart.rake', __FILE__)


### PR DESCRIPTION
The correct file path is `lib/capistrano/php_fpm/php_fpm.rake` but it is `lib/capistrano/php_fpm/php-fpm.rake`.

**Capfile**
```
require 'capistrano/php_fpm/sysv_upstart'
```

**deploy.rb**
```
namespace :deploy do
  after :finishing, 'php_fpm:reload'
end
```

**ERROR**
```
> bundle exec cap staging deploy
(Backtrace restricted to imported tasks)
cap aborted!
LoadError: cannot load such file -- /home/app/app-config/app-deploy/vendor/bundle/ruby/2.2.0/gems/capistrano-php-fpm-2.0.0/lib/capistrano/php_fpm/php-fpm.rake
/home/app/app/app-deploy/Capfile:6:in `require'
/home/app/app/app-deploy/Capfile:6:in `<top (required)>'
(See full trace by running task with --trace)
```