### PR TITLE
[systemd] Allow to configure service name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Configurable options shown here are also the defaults:
 set :php_fpm_with_sudo, true
 set :php_fpm_roles, :web
 set :php_fpm_service_name, 'php-fpm' # Change this if you have non-standard naming for the php-fpm service
+set :php_fpm_service_suffix, '.service' # Only used for systemd environment, change this if your service name is not sufixed by this
 set :systemctl_location, '/bin/systemctl' # May already exist if you use other plugins. Be sure to check your config/deploy/{env} file
 ```
 

--- a/lib/capistrano/php_fpm/php_fpm.rake
+++ b/lib/capistrano/php_fpm/php_fpm.rake
@@ -3,6 +3,7 @@ namespace :load do
     set :php_fpm_with_sudo, true
     set :php_fpm_roles, :web
     set :php_fpm_service_name, 'php-fpm'
+    set :php_fpm_service_suffix, '.service'
     set :systemctl_location, '/bin/systemctl'
   end
 end

--- a/lib/capistrano/php_fpm/tasks/systemd.rake
+++ b/lib/capistrano/php_fpm/tasks/systemd.rake
@@ -2,35 +2,35 @@ namespace :'php_fpm' do
   desc 'Reload php_fpm'
   task :reload do
     on release_roles(fetch(:php_fpm_roles)) do
-      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "reload #{fetch(:php_fpm_service_name)}.service") : execute(fetch(:systemctl_location), "reload #{fetch(:php_fpm_service_name)}.service")
+      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "reload #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}") : execute(fetch(:systemctl_location), "reload #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}")
     end
   end
 
   desc 'Zap php_fpm'
   task :zap do
     on release_roles(fetch(:php_fpm_roles)) do
-      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "zap #{fetch(:php_fpm_service_name)}.service") : execute(fetch(:systemctl_location), "zap #{fetch(:php_fpm_service_name)}.service")
+      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "zap #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}") : execute(fetch(:systemctl_location), "zap #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}")
     end
   end
 
   desc 'Stop php_fpm'
   task :stop do
     on release_roles(fetch(:php_fpm_roles)) do
-      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "stop #{fetch(:php_fpm_service_name)}.service") : execute(fetch(:systemctl_location), "stop #{fetch(:php_fpm_service_name)}.service")
+      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "stop #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}") : execute(fetch(:systemctl_location), "stop #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}")
     end
   end
 
   desc 'Start php_fpm'
   task :start do
     on release_roles(fetch(:php_fpm_roles)) do
-      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "start #{fetch(:php_fpm_service_name)}.service") : execute(fetch(:systemctl_location), "start #{fetch(:php_fpm_service_name)}.service")
+      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "start #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}") : execute(fetch(:systemctl_location), "start #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}")
     end
   end
 
   desc 'Restart php_fpm'
   task :restart do
     on release_roles(fetch(:php_fpm_roles)) do
-      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "restart #{fetch(:php_fpm_service_name)}.service") : execute(fetch(:systemctl_location), "restart #{fetch(:php_fpm_service_name)}.service")
+      fetch(:php_fpm_with_sudo) ? execute(:sudo, fetch(:systemctl_location), "restart #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}") : execute(fetch(:systemctl_location), "restart #{fetch(:php_fpm_service_name)}#{fetch(:php_fpm_service_suffix)}")
     end
   end
 end


### PR DESCRIPTION
Because my service name is not `php-fpm.service` but `php7.2-fpm` so I need to be able to configure both service name and the suffix.

It should be full compatible as with default value the service in the command is `php-fpm.service` by default for `systemd`.

Thanks for your plugin !